### PR TITLE
fix: return data within resolver function of getCurrentUser()

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -46,7 +46,7 @@ export default function actionsFactory(config) {
           }
           // Call AUTHENTICATE because it's utterly the same
           commit(types.AUTHENTICATE, constructUser(cognitoUser, session));
-          resolve();
+          resolve({currentUser: cognitoUser});
         });
       });
     },


### PR DESCRIPTION
When requesting a user via the `getCurrentUser()` action a fulfilled promise doesn't have any actual data.