### PR TITLE
Add cognitoAuthenticated getter to determine whether session is active

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -14,6 +14,7 @@ function constructUser(cognitoUser, session) {
       AccessToken: session.getAccessToken().getJwtToken(),
       RefreshToken: session.getRefreshToken().getToken(),
     },
+    expiration: session.getAccessToken().getExpiration(),
     attributes: {},
   };
 }

--- a/src/getters.js
+++ b/src/getters.js
@@ -1,0 +1,10 @@
+export default {
+  cognitoAuthenticated: state => {
+    let now = Math.floor(new Date() / 1000)
+
+    return !(state.user === null
+      || (state.user && state.user.tokens === null)
+      || now > state.user.expiration
+    )
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import ActionsFactory from './actions';
 import mutations from './mutations';
+import getters from './getters';
 
 const state = {
   user: null,
@@ -27,5 +28,6 @@ export default class CognitoAuth {
     this.state = state;
     this.actions = new ActionsFactory(config);
     this.mutations = mutations;
+    this.getters = getters;
   }
 }


### PR DESCRIPTION
Currently, it is impossible to determine if a session has timed out.
This adds a getter that validates the session expiration against the current time.
amazon-cognito-identity-js uses the cognitoSession class to do this, which would be ideal, but I think this approach works.